### PR TITLE
fix: on backend gen found typo in tpl.

### DIFF
--- a/fsm/tpl.go
+++ b/fsm/tpl.go
@@ -47,7 +47,7 @@ func WithActionHandler(h {{.Struct.Name}}HandleAction) Option {
 	}
 }
 
-func WithPersiter(p {{.Struct.Name}}PersistState) Option {
+func WithPersister(p {{.Struct.Name}}PersistState) Option {
 	return func(fsm *{{.Struct.Name}}StateMachine) {
 		fsm.persister = p
 	}


### PR DESCRIPTION
Нашел опечатку, которая расфигачивает клиенсткий код =) - его конечно можно переписать - но зачем? =)
